### PR TITLE
avoid Timeout.timeout use

### DIFF
--- a/lib/future-resource.rb
+++ b/lib/future-resource.rb
@@ -61,7 +61,7 @@ class FutureResource
   # @return [Object]
   #
   def resource(timeout = nil)
-    Timeout::timeout timeout do
+    ::Timeout::timeout timeout do
       @resource_lock.synchronize do
         @resource_value_blocker.wait unless set_yet? or terminated?
         raise Terminated if terminated?
@@ -115,6 +115,8 @@ class FutureResource
       super "Resource read attempt terminated"
     end
   end
+
+  Timeout = ::Timeout::Error
 
   private
 

--- a/spec/future-resource_spec.rb
+++ b/spec/future-resource_spec.rb
@@ -20,7 +20,9 @@ describe FutureResource do
     it { should be_set_yet }
     it { should_not be_terminated }
 
-    its(:resource) { should === :foo }
+    it "should have resource set" do
+      expect(subject.resource).to be :foo
+    end
 
     it "should raise ResourceAlreadySetException when setting value that is already set" do
       expect {
@@ -65,7 +67,7 @@ describe FutureResource do
       sleep 1
       subject.resource = :foo
     end
-    subject.resource.should === :foo
+    expect(subject.resource).to be :foo
   end
 
   it "should raise on timeout" do
@@ -78,6 +80,6 @@ describe FutureResource do
       sleep 1
       subject.resource = :foo
     end
-    subject.resource.should === :foo
+    expect(subject.resource).to be :foo
   end
 end

--- a/spec/future-resource_spec.rb
+++ b/spec/future-resource_spec.rb
@@ -68,6 +68,10 @@ describe FutureResource do
     subject.resource.should === :foo
   end
 
+  it "should raise on timeout" do
+    expect { subject.resource(0.5) }.to raise_error FutureResource::Timeout
+  end
+
   it "should allow an alternative condition to be provided" do
     resource = described_class.new(ConditionVariable.new)
     Thread.new do


### PR DESCRIPTION
with backwards compatibility - for now - still raising `Timeout::Error`

thus avoid using another thread for time tracking `ConditionVariable` already supports timeout (sleep)